### PR TITLE
Remove redundant Quaternion -> euler angle conversion

### DIFF
--- a/Assets/fastVR-sdk/Scripts/Relativ_player.cs
+++ b/Assets/fastVR-sdk/Scripts/Relativ_player.cs
@@ -55,7 +55,7 @@ public class Relativ_player : MonoBehaviour {
 		float y = float.Parse (values[1]);
 		float z = float.Parse (values[2]);
 
-		transform.rotation = new Quaternion(x, y, z, w);
+		transform.localRotation = new Quaternion(x, y, z, w);
 
 	}
 

--- a/Assets/fastVR-sdk/Scripts/Relativ_player.cs
+++ b/Assets/fastVR-sdk/Scripts/Relativ_player.cs
@@ -54,9 +54,8 @@ public class Relativ_player : MonoBehaviour {
 		float x = float.Parse (values[0]);
 		float y = float.Parse (values[1]);
 		float z = float.Parse (values[2]);
-		float[] EulerAngles = Relativ_math_transform.getEuler(w, x, y, z);
 
-		transform.localEulerAngles = new Vector3 (EulerAngles[0],EulerAngles[1],EulerAngles[2]);
+		transform.rotation = new Quaternion(x, y, z, w);
 
 	}
 


### PR DESCRIPTION
Just a quick change that effectively replaces 
```cs
transform.localEulerAngles = new Quaternion(x, y, z, w).eulerAngles;
```
with
```cs
transform.rotation = new Quaternion(x, y, z, w);
```

Sidenote: Your `getEuler` method takes `w, x, y, z`, while Unity's `Quaternion` constructor uses `x, y, z, w`.

Just wanted to show you that Unity and almost all other engines and frameworks come with most math-related methods you'll need, and that the transform uses `Quaternion`s behind the scenes. The Unity Inspector UI just converts between `Quaternion`s and Euler angles - you don't need to do so.

I'm unable to test my changes as I don't own the required hardware.